### PR TITLE
Parz coin now has a very small chance of being unchanged since last time

### DIFF
--- a/cogs/funcommands.py
+++ b/cogs/funcommands.py
@@ -304,7 +304,7 @@ class Funcommands(commands.Cog):
 
         direction = random.choice(["up", "down"])
 
-        floor = 1
+        floor = 0
 
         if self.parz_coin_value > 999.0:
             direction = "down"
@@ -320,10 +320,16 @@ class Funcommands(commands.Cog):
             percent = random.randint(floor, 75)
             self.parz_coin_value *= 1 - (percent / 100)
 
-        print_direction = "UP 📈" if direction == "up" else "DOWN 📉"
+        if percent == 0:
+            print_str = "Parz Coin is **UNCHANGED** since last time!"
+        else:
+            print_direction = "UP 📈" if direction == "up" else "DOWN 📉"
+            print_str = (
+                f"Parz Coin is **{print_direction} {percent}%** since last time!"
+            )
 
         await ctx.send(
-            f"Parz Coin is **{print_direction} {percent}%** since the last time!\nCurrent value: 0.{self.parz_coin_value:015.0f} USD"
+            f"{print_str}\nCurrent value: 0.{self.parz_coin_value:015.0f} USD"
         )
 
 


### PR DESCRIPTION
## Summary

- Parz coin may now be unchanged since last time. 
- Also reworded "since the last time" to "since last time"
- Message for unchanged lacks emoji like the UP and DOWN messages do, no corresponding emoji exists for flat graph unfortunately. Could consider the neutral face emoji for example
- Tested roughly in a Jupyter cell, not in a running instance of the bot.

## Checklist
<!-- Put an x inside [ ] to check it: [x] -->

- [x ] This PR makes changes to the functionality of the code.
  - [ ] This PR fixes a bug.
  - [ ] This PR adds something new.
  - [x/2] **I have tested the changes made.**

- [ ] This PR fixes typos in the code or errors in the documentation.
- [ ] Other/Not described.
